### PR TITLE
Parameterize nginx config

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -39,4 +39,5 @@ RUN mkdir -p /home/app/freeboard/dashboard \
 
 # register playground website in nginx
 ADD playground.conf /etc/nginx/sites-enabled/playground.conf
+ADD perl-variables.conf /etc/nginx/conf.d/perl-variables.conf
 ADD nginx-env.conf /etc/nginx/main.d/nginx-env.conf

--- a/Docker/perl-variables.conf
+++ b/Docker/perl-variables.conf
@@ -1,0 +1,2 @@
+perl_set $dh_admin_url 'sub {return $ENV{"DH_ADMIN_URL"}; }';
+perl_set $dh_api_url 'sub {return $ENV{"DH_API_URL"}; }';

--- a/Docker/playground.conf
+++ b/Docker/playground.conf
@@ -22,7 +22,7 @@ server {
 
     location /admin {
         proxy_redirect off;
-        proxy_pass "http://dh_admin:8080";
+        proxy_pass $dh_admin_url;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_http_version 1.1;
@@ -32,7 +32,7 @@ server {
 
     location /api/ {
         proxy_redirect off;
-        proxy_pass "http://dh_frontend:8080";
+        proxy_pass $dh_api_url;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_http_version 1.1;


### PR DESCRIPTION
Nginx can't use env variables in its configs. That's why I'm using Perl
module there to set them.